### PR TITLE
Chapter 6: Properly set from address on outbound applicant emails

### DIFF
--- a/app/mailers/applicant_mailer.rb
+++ b/app/mailers/applicant_mailer.rb
@@ -6,7 +6,7 @@ class ApplicantMailer < ApplicationMailer
 
     mail(
       to: @applicant.email,
-      from: @user.email,
+      from: "reply-#{@user.email_alias}@hotwiringrails.com",
       subject: @email.subject
     )
   end


### PR DESCRIPTION
Changes `from` address in `ApplicantMailer` to use the user's `email_alias` to correctly route replies.