### PR TITLE
Chapter 4.1

### DIFF
--- a/app/javascript/controllers/drag_controller.js
+++ b/app/javascript/controllers/drag_controller.js
@@ -8,7 +8,7 @@ export default class extends Controller {
     attribute: String
   }
 
-  connect() {
+  listTargetConnected() {
     this.listTargets.forEach(this.initializeSortable.bind(this))
   }
 


### PR DESCRIPTION
This small adjustment resolves an issue causing dragging to break after applying filters to the applicant page — using `listTargetConnected` instead of `connect` ensures that sortable is initialized after the list re-renders.

HT to https://github.com/GGrassiant for surfacing this problem.