### PR TITLE
Chapter 10.1

### DIFF
--- a/app/javascript/controllers/charts_controller.js
+++ b/app/javascript/controllers/charts_controller.js
@@ -14,6 +14,10 @@ export default class extends ApplicationController {
     this.chart.render();
   }
 
+  disconnect() {
+    this.chart.destroy();
+  }
+
   afterUpdate() {
     this.chart.updateOptions(this.chartOptions);
   }

--- a/app/views/charts/_applicants_chart.html.erb
+++ b/app/views/charts/_applicants_chart.html.erb
@@ -3,6 +3,7 @@
   data-applicants-chart-labels-value="<%= labels %>"
   data-applicants-chart-series-value="<%= series %>"
   id="applicants-chart-container"
+  data-turbo-cache="false"
 >
   <div class="flex justify-between">
     <h3 class="text-xl font-bold text-blue-700">Applicants by hiring stage</h3>

--- a/app/views/charts/_hiring_stages_chart.html.erb
+++ b/app/views/charts/_hiring_stages_chart.html.erb
@@ -3,6 +3,7 @@
   data-hiring-stages-labels-value="<%= labels %>"
   data-hiring-stages-series-value="<%= series %>"
   id="stage-chart-container"
+  data-turbo-cache="false"
 >
   <div class="flex justify-between">
     <h3 class="text-xl font-bold text-blue-700">Applicants by hiring stage</h3>


### PR DESCRIPTION
This PR destroys the charts when the chart controller is disconnected from the DOM and resolves flickering caused by Turbo displaying a cached versions of the charts.