### PR TITLE
Chapter 1.1 — Fix breaking change with Stimulus 3.1 package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "mrujs": "^0.8.0",
     "postcss": "^8.4.5",
     "postcss-import": "^14.0.2",
-    "stimulus": "^3.0.1",
+    "@hotwired/stimulus": "^3.1.0",
+    "stimulus": "npm:@hotwired/stimulus",
     "stimulus_reflex": "^3.5.0-pre8",
     "tailwindcss": "^3.0.15"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,15 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@hotwired/stimulus-webpack-helpers@^1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@hotwired/stimulus-webpack-helpers/-/stimulus-webpack-helpers-1.0.1.tgz#4cd74487adeca576c9865ac2b9fe5cb20cef16dd"
-  integrity sha512-wa/zupVG0eWxRYJjC1IiPBdt3Lruv0RqGN+/DTMmUWUyMAEB27KXmVY6a8YpUVTM7QwVuaLNGW4EqDgrS2upXQ==
-
-"@hotwired/stimulus@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.0.1.tgz#141f15645acaa3b133b7c247cad58ae252ffae85"
-  integrity sha512-oHsJhgY2cip+K2ED7vKUNd2P+BEswVhrCYcJ802DSsblJFv7mPFVk3cQKvm2vHgHeDVdnj7oOKrBbzp1u8D+KA==
+"@hotwired/stimulus@^3.1.0", "stimulus@npm:@hotwired/stimulus":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.1.0.tgz#20215251e5afe6e0a3787285181ba1bfc9097df0"
+  integrity sha512-iDMHUhiEJ1xFeicyHcZQQgBzhtk5mPR0QZO3L6wtqzMsJEk2TKECuCQTGKjm+KJTHVY0dKq1dOOAWvODjpd2Mg==
 
 "@hotwired/turbo-rails@^7.1.1":
   version "7.1.1"
@@ -763,14 +758,6 @@ source-map-js@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
-
-stimulus@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/stimulus/-/stimulus-3.0.1.tgz#370e3054eb3b8068904af1888949821255d375d3"
-  integrity sha512-73uZG5E5bwH7W2BldieTXg4yJuEmOfIHgtO/aqwU0JkWNjwY75ZaoOAD2EEPvi5AK43N9adEeOQOmlgWf59HOg==
-  dependencies:
-    "@hotwired/stimulus" "^3.0.1"
-    "@hotwired/stimulus-webpack-helpers" "^1.0.0"
 
 stimulus_reflex@^3.5.0-pre8:
   version "3.5.0-pre8"


### PR DESCRIPTION
This PR adjusts the package.json to properly import the stimulus "glue" package (named `stimulus` instead of `@hotwired/stimulus`) that StimulusReflex relies on. Prior to Stimulus 3.1 release, we could just add stimulus instead of `@hotwired/stimulus` to the bundle and we were good to go. Now, perhaps because of the glue package hasn't been updated yet, we need to import both packages as seen in this PR.

Open source software!